### PR TITLE
Add footer on all pages

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AppProps } from 'next/app';
 import { ChakraProvider } from '@chakra-ui/react';
+import Footer from '../components/Footer';
 import Header from '../components/Header';
 import theme from '../styles/theme';
 
@@ -9,6 +10,7 @@ function MyApp({ Component, pageProps }: AppProps): React.ReactNode {
     <ChakraProvider theme={theme}>
       <Header />
       <Component {...pageProps} />
+      <Footer />
     </ChakraProvider>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,7 +12,6 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react';
-import Footer from '../components/Footer';
 
 export default function Home() {
   return (
@@ -61,7 +60,6 @@ export default function Home() {
             </VStack>
           </Center>
         </SimpleGrid>
-        <Footer />
       </Box>
     </>
   );


### PR DESCRIPTION
**Context:** initially thought that the header did render only on the homepage. But, the is rendered on all pages. So, only the footer was needed to add on all pages.

**Development:** the footer component was removed from the homepage and added to the app to be rendered on all pages.